### PR TITLE
Add GParser library to fix WiFi setup.

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -1,3 +1,8 @@
+#include <parseUtils.h>
+#include <GParser.h>
+#include <unicode.h>
+#include <url.h>
+
 //Joseph Hewitt 2021
 //This code is for the ESP32 "Side A" of the wardriver hardware revision 3.
 
@@ -209,10 +214,10 @@ void boot_config(){
                 Serial.println("Got WiFi config");
                 int startpos = buff.indexOf("?ssid=")+6;
                 int endpos = buff.indexOf("&");
-                String new_ssid = buff.substring(startpos,endpos);
+                String new_ssid = GP_urldecode(buff.substring(startpos,endpos));
                 startpos = buff.indexOf("&psk=")+5;
                 endpos = buff.indexOf(" HTTP");
-                String new_psk = buff.substring(startpos,endpos);
+                String new_psk = GP_urldecode(buff.substring(startpos,endpos));
 
                 Serial.println(new_ssid);
                 preferences.putString("ssid", new_ssid);
@@ -238,10 +243,10 @@ void boot_config(){
                 Serial.println("Got WiFi (fallback) config");
                 int startpos = buff.indexOf("?ssid=")+6;
                 int endpos = buff.indexOf("&");
-                String new_ssid = buff.substring(startpos,endpos);
+                String new_ssid = GP_urldecode(buff.substring(startpos,endpos));
                 startpos = buff.indexOf("&psk=")+5;
                 endpos = buff.indexOf(" HTTP");
-                String new_psk = buff.substring(startpos,endpos);
+                String new_psk = GP_urldecode(buff.substring(startpos,endpos));
 
                 Serial.println(new_ssid);
                 preferences.putString("fbssid", new_ssid);
@@ -286,10 +291,10 @@ void boot_config(){
   bootcount++;
   preferences.putULong("bootcount", bootcount);
 
-  String con_ssid = preferences.getString("ssid","");
-  String con_psk = preferences.getString("psk","");
-  String fb_ssid = preferences.getString("fbssid","");
-  String fb_psk = preferences.getString("fbpsk","");
+  String con_ssid = GP_urldecode(preferences.getString("ssid",""));
+  String con_psk = GP_urldecode(preferences.getString("psk",""));
+  String fb_ssid = GP_urldecode(preferences.getString("fbssid",""));
+  String fb_psk = GP_urldecode(preferences.getString("fbpsk",""));
   boolean created_network = false; //Set to true automatically when the fallback network is created.
 
   if (con_ssid != "" || fb_ssid != ""){

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In order for the project to compile, you need to download the following librarie
 - [Adafruit GFX Library](https://github.com/adafruit/Adafruit-GFX-Library) v1.10.x by Adafruit
 - [Adafruit SSD1306](https://github.com/adafruit/Adafruit_SSD1306) v2.4.x by Adafruit
 - [OneWire](https://www.pjrc.com/teensy/td_libs_OneWire.html) v2.3.x by Paul Stoffregen
+- [GParser](https://github.com/GyverLibs/GParser) v1.4.x by AlexGyver
 
 If using the official PCB, the code in "B" corresponds to the board soldered above the silkscreen text "Made by Joseph Hewitt". The source file "A" is for the remaining ESP32. You may flash the boards when they are soldered to the PCB or before soldering -- it's your choice.
 


### PR DESCRIPTION
Added the GParser library to do URLdecodes on the SSID and PSK fields sent during setup. I ran through the setup on my home network which has spaces in the SSID and special characters in the PSK.  I added it to both the setup process, as well as the connection process to allow a simple upgrade without needing to re-run setup for existing users.