### PR TITLE
Dynamically determine device revision

### DIFF
--- a/B/B.ino
+++ b/B/B.ino
@@ -163,7 +163,7 @@ void setup() {
   }
 
   Serial1.begin(115200,SERIAL_8N1,27,14); //ESP A, pins 27/14
-  Serial1.println("STARTING");
+  Serial1.println("REV3!");
 
   Serial2.begin(9600); //SIM800L
   delay(50);
@@ -210,6 +210,7 @@ void setup() {
       0); /* Core where the task should run */
 
   Serial.println("Started");
+  Serial1.println("REV3!");
   if (!temperature_sensor_ok){
     //If there's no temperature sensor, attempt to put a warning on the LCD.
     //This is side B so there should be no LCD. This should only be visible if side A is flashed with this code.


### PR DESCRIPTION
No longer hardcode Rev3, determine it automatically.

TODO: "Side B" can send `REV3!` or `!REV3.5` to quickly identify themselves, but this isn't yet programmed into rev3 side B.