### PR TITLE
Increase stack size, enable strict hash check

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -24,6 +24,9 @@ const String VERSION = "1.2.0b2";
 #define OLED_RESET     -1 // Reset pin # (or -1 if sharing Arduino reset pin)
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
+//The stack size is insufficient for the OTA hashing calls. This is 10K, instead of the default 8K.
+SET_LOOP_TASK_STACK_SIZE(10240);
+
 //These variables are used for buffering/caching GPS data.
 char nmeaBuffer[100];
 MicroNMEA nmea(nmeaBuffer, sizeof(nmeaBuffer));
@@ -508,13 +511,11 @@ boolean install_firmware(String filepath, String expect_hash = "") {
     //At this point, make a HTTPS request to an API which can validate the .bin checksum.
     //Fail here if the checksum is a mismatch.
     
-    /*String check_result = online_hash_check(actual_hash);
+    String check_result = online_hash_check(actual_hash);
     if (check_result == ""){
       Serial.println("Strict online hash check mismatch, aborting");
       return false;
-    }*/
-
-    //This feature causes a crash. Likely because of too much memory being used or being too many functions deep.
+    }
     
   }
 
@@ -1559,7 +1560,7 @@ void setup() {
     display.display();
     
     int reset_reason = esp_reset_reason();
-    if (reset_reason != ESP_RST_POWERON){
+    if (reset_reason != ESP_RST_POWERON && reset_reason != ESP_RST_SW){
       clear_display();
       display.println("Unexpected reset");
       display.print("Code ");


### PR DESCRIPTION
Increase stack size, re-enable 'enforce valid hash on install' which was crashing in #86 due to insufficient stack space.
Don't print "unexpected reset" when doing a software reset.