### PR TITLE
Fix HDOP display on screen

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -1812,7 +1812,7 @@ void lcd_show_stats(){
   display.println();
   if (nmea.getHDOP() < 250 && nmea.getNumSatellites() > 0){
     display.print("HDOP:");
-    display.print(nmea.getHDOP());
+    display.print(((float)nmea.getHDOP()/10));
     display.print(" Sats:");
     display.print(nmea.getNumSatellites());
     display.println(nmea.getNavSystem());


### PR DESCRIPTION
MicroNMEA reports HDOP in tenths. Using the same method to fix HDOP as used for calculating accuracy in the CSV.