### PR TITLE
Stop clearing MAC history on side B

### DIFF
--- a/B/B.ino
+++ b/B/B.ino
@@ -370,7 +370,6 @@ void loop() {
       }
     }
   }
-  clear_mac_history();
   BLEScanResults foundDevices = pBLEScan->start(2.5, false);
   await_serial();
   serial_lock = true;


### PR DESCRIPTION
Addresses #104 by removing the clear history function call from within the loop.