### PR TITLE
Add support for using ESP32 pins to identify board for configuration.

### DIFF
--- a/B/B.ino
+++ b/B/B.ino
@@ -161,6 +161,17 @@ void setup() {
   Serial1.print("RESET=");
   Serial1.println(reset_reason);
 
+  setup_id_pins();
+  byte board_id = read_id_pins();
+
+  switch(board_id){
+    case 1:                 // CoD_Segfault Mini Wardriver Rev2
+      using_bw16 = true;    // All units have BW16
+      break;
+    default:                // Any boards not using ID pins will be assumed 
+      break;                // to rely on config files for all parameters
+  }
+
   Serial.println("Waiting for config vars");
   Serial1.println("SEND_CONF");
   Serial1.flush();
@@ -620,3 +631,22 @@ void clear_mac_history(){
 
   mac_history_cursor = 0;
 }
+
+void setup_id_pins(){
+  pinMode(13, INPUT_PULLUP); // IO13 is A/B identifier pin
+  pinMode(25, INPUT_PULLDOWN); // All other pins are board identifers
+  pinMode(26, INPUT_PULLDOWN);
+  pinMode(32, INPUT_PULLDOWN);
+  pinMode(33, INPUT_PULLDOWN);
+}
+
+byte read_id_pins(){
+  byte board_id = 0;
+  board_id = digitalRead(25);                     // shift bits to get a board ID
+  board_id = (board_id << 1) + digitalRead(26);
+  board_id = (board_id << 1) + digitalRead(32);
+  board_id = (board_id << 1) + digitalRead(33);
+
+  return board_id;
+}
+


### PR DESCRIPTION
Adding initial support for using GPIO pin-based board variant detection. This will allow different boards to be identified and configuration be made without needing to use the config file on the SD card. This uses GPIO13 to identify whether it is a ESP32 A or B, and GPIO25, 26, 32, and 33 to create an identification byte. This will allow for up to 15 variants (1-15) to be detected, with the pulldowns creating a default configuration (0) that falls back on the config file as it has been functioning.

As we have already discussed, more work will need to be done to parameterize the device string for the CSV header.