### PR TITLE
Bump version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 *.bin
 .vscode
+build/

--- a/A/A.ino
+++ b/A/A.ino
@@ -1,7 +1,7 @@
 //Joseph Hewitt 2023
 //This code is for the ESP32 "Side A" of the wardriver hardware revision 3.
 
-const String VERSION = "1.2.0rc2";
+const String VERSION = "1.2.0";
 
 #include <GParser.h>
 #include <MicroNMEA.h>


### PR DESCRIPTION
Bump version number for 1.2.0 release.
Added `build/` to `.gitignore` since this is created as part of CLI compilation of the project.