### PR TITLE
Stop locking Serial1 during BLE scan

### DIFF
--- a/B/B.ino
+++ b/B/B.ino
@@ -79,13 +79,16 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
 
           String ble_name = advertisedDevice.getName().c_str();
           ble_name.replace(",","_");
-          
+
+          await_serial();
+          serial_lock = true;
           Serial1.print("BL,");
           Serial1.print(advertisedDevice.getRSSI());
           Serial1.print(",");
           Serial1.print(advertisedDevice.getAddress().toString().c_str());
           Serial1.print(",");
           Serial1.println(ble_name);
+          serial_lock = false;
         }
       }
     }
@@ -393,9 +396,9 @@ void loop() {
     }
   }
 
+  BLEScanResults* foundDevices = pBLEScan->start(1.8, false);
   await_serial();
   serial_lock = true;
-  BLEScanResults* foundDevices = pBLEScan->start(1.8, false);
   Serial1.print("BLC,");
   Serial1.println(ble_found);
   serial_lock = false;


### PR DESCRIPTION
Locking Serial1 during BLE scan increases the risk of losing scan data from the BW16. Moved lock to just around the serial writing code.