### PR TITLE
Allow WiFi con & psk to be changed in stored preferences via cfg.txt parameter

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -1549,7 +1549,8 @@ void boot_config(){
   if (con_ssid != "" || fb_ssid != ""){
     Serial.print("Attempting to connect to WiFi");
     clear_display();
-    display.print("Connecting");
+    display.print("Connecting to:");
+    display.print(con_ssid);   // show the WiFi network name
     display.display();
     if (con_ssid != ""){
       WiFi.begin(con_ssid, con_psk);

--- a/A/A.ino
+++ b/A/A.ino
@@ -172,6 +172,7 @@ float force_lon = 0;
 boolean sb_bw16 = false;
 boolean scanble = true;  // Bluetooth scan preference
 boolean tempunits_c = true; // Temperature in Celsius by default
+boolean con_ssid_update = false; // update stored WiFi info with cfg.txt values?
 
 #define MAX_AUTO_RESET_MS 1814400000
 #define MIN_AUTO_RESET_MS 7200000
@@ -1267,6 +1268,7 @@ void boot_config(){
 // BlueTooth scan preference
   scanble = get_config_bool("scanble", scanble);
   tempunits_c = get_config_bool("tempunits_c", tempunits_c); // temperature in C or F
+  con_ssid_update = get_config_bool("con_ssid_update", con_ssid_update); // update stored WiFi info?
 
   if (auto_reset_ms != 0){
     if (auto_reset_ms > MAX_AUTO_RESET_MS){
@@ -1526,7 +1528,14 @@ void boot_config(){
   fb_ssid = get_config_string("fb_ssid", fb_ssid);
   fb_psk = get_config_string("fb_psk", fb_psk);
   boolean created_network = false; //Set to true automatically when the fallback network is created.
-  
+
+  // update the WiFi connection information into preferences if requested
+  if (con_ssid_update) {
+    preferences.putString("ssid",con_ssid);
+    preferences.putString("psk",con_psk);
+    Serial.println("* Updated saved WiFi SSID & PSK");
+  }
+
   boolean is_stable = true; //Currently running beta or stable, set automatically
   //Maybe set this to check for any letters, since normal stable version numbers probably don't have any letters.
   //This should catch rc versions and beta versions though.


### PR DESCRIPTION
Provides a way to change the stored WiFi information without having to leave the con_ssid and con_psk values in clear text in the cfg.txt file.  Adds a new "con_ssid_update" boolean value for cfg.txt.

This item will need an addition to the wiki for the new parameter and explanation:

Parameter - con_ssid_update (boolean)
Default value: no / false
Use: When you want to change the WiFi network your war driver connects to for data uploads without leaving the WiFi network information in cfg.txt in plain text
Steps:
- Add 'con_ssid_update=yes' to cfg.txt
- Add your new 'con_ssid' and 'con_psk' values to cfg.txt
- Boot once and the new con_ssid and con_psk values are saved.
- Remove the con_ssid and con_psk values from cfg.txt
- Change "con_ssid_update=no", or remove the parameter from cfg.txt
