### PR TITLE
Increase baud rate for A-B UART

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -196,6 +196,7 @@ boolean tempunits_c = true; // Temperature in Celsius by default
 boolean con_ssid_update = false; // update stored WiFi info with cfg.txt values?
 unsigned long pcb_baud_rate_high = 921600;
 
+#define MAX_PCB_BAUD_RATE_HIGH 4000000 //Anything above 4Mhz is likely going to be unreliable, so cap it there.
 #define MAX_AUTO_RESET_MS 1814400000
 #define MIN_AUTO_RESET_MS 7200000
 
@@ -1266,6 +1267,13 @@ void boot_config(){
   tempunits_c = get_config_bool("tempunits_c", tempunits_c); // temperature in C or F
   con_ssid_update = get_config_bool("con_ssid_update", con_ssid_update); // update stored WiFi info?
   pcb_baud_rate_high = get_config_int("pcb_baud_rate_high", pcb_baud_rate_high);
+  
+  if (pcb_baud_rate_high < PCB_BAUD_RATE_DEFAULT){
+    pcb_baud_rate_high = PCB_BAUD_RATE_DEFAULT;
+  }
+  if (pcb_baud_rate_high > MAX_PCB_BAUD_RATE_HIGH){
+    pcb_baud_rate_high = MAX_PCB_BAUD_RATE_HIGH;
+  }
 
   if (auto_reset_ms != 0){
     if (auto_reset_ms > MAX_AUTO_RESET_MS){
@@ -2456,6 +2464,9 @@ void setup() {
     pcb_baud_rate = preferences.getULong("pcb_baud_rate",0);
     if (pcb_baud_rate < PCB_BAUD_RATE_DEFAULT){
       pcb_baud_rate = PCB_BAUD_RATE_DEFAULT;
+    }
+    if (pcb_baud_rate > MAX_PCB_BAUD_RATE_HIGH){
+      pcb_baud_rate = MAX_PCB_BAUD_RATE_HIGH;
     }
     preferences.end();
 


### PR DESCRIPTION
An extra parameter is now available (adjustable via `cfg.txt` as `pcb_baud_rate_high`), which is a baud rate the wardriver will attempt to mutually switch to along with Side B. The default value for this is 921600.

After increasing the rate, the connection will be tested and reverted if it seems unreliable. If Side B is running old firmware, Side A should notice and keep the baud rate on the default which is defined at 115200 (this is the baud that has been in use since the 1.0.0 release).

Both Side A and B will remember the new rate (if it is confirmed to work), and will immediately use it for all future sessions, unless it is changed again.

Side A will attempt to fix broken connections due to baud rate mismatches (which can happen if something gets a factory-reset or if an ESP is replaced). However, this can fail if `pcb_baud_rate_high` is altered at the same time. Side B will never change its baud rate unless explicitly told to do so (but this requires a working connection).