### PR TITLE
Update read.me with information about Arduino IDE Core Debug Level parameter for logging

### DIFF
--- a/A/A.ino
+++ b/A/A.ino
@@ -195,6 +195,7 @@ boolean scanble = true;  // Bluetooth scan preference
 boolean tempunits_c = true; // Temperature in Celsius by default
 boolean con_ssid_update = false; // update stored WiFi info with cfg.txt values?
 unsigned long pcb_baud_rate_high = 921600;
+boolean scan_passive = false; // WiFi scan in passive mode? - Default = FALSE (active scan) - does NOT apply to BW16
 
 #define MAX_PCB_BAUD_RATE_HIGH 4000000 //Anything above 4Mhz is likely going to be unreliable, so cap it there.
 #define MAX_AUTO_RESET_MS 1814400000
@@ -1273,6 +1274,7 @@ void boot_config(){
   tempunits_c = get_config_bool("tempunits_c", tempunits_c); // temperature in C or F
   con_ssid_update = get_config_bool("con_ssid_update", con_ssid_update); // update stored WiFi info?
   pcb_baud_rate_high = get_config_int("pcb_baud_rate_high", pcb_baud_rate_high);
+  scan_passive = get_config_bool("scan_passive", scan_passive);  // WiFi scanning mode - passive or active flag
   
   if (pcb_baud_rate_high < PCB_BAUD_RATE_DEFAULT){
     pcb_baud_rate_high = PCB_BAUD_RATE_DEFAULT;
@@ -2447,6 +2449,7 @@ void send_config_to_b(){
   push_config("sb_bw16");
   // BlueTooth scan preference
   push_config("scanble");
+  push_config("scan_passive");  // WiFi scanning mode - passive or active flag
 }
 
 void setup() {
@@ -2732,15 +2735,17 @@ unsigned long millis_main(){
 void primary_scan_loop(void * parameter){
   //This core will be dedicated entirely to WiFi scanning in an infinite loop.
   setup_wifi();
+  ESP_LOGI(LOG_TAG_GENERIC, "Scanning in Passive mode: %s", scan_passive ? "true" : "false");
+
   while (true){
     disp_wifi_count = wifi_count;
     wifi_count = 0;
-    
+
     for(int scan_channel = 1; scan_channel < 12; scan_channel++){
       yield();
       ESP_LOGV(LOG_TAG_GENERIC, "Start Scan C%i", scan_channel);
       //scanNetworks(bool async, bool show_hidden, bool passive, uint32_t max_ms_per_chan, uint8_t channel)
-      int n = WiFi.scanNetworks(false,true,false,110,scan_channel);
+      int n = WiFi.scanNetworks(false,true,scan_passive,110,scan_channel);
       ESP_LOGV(LOG_TAG_GENERIC, "Finish Scan C%i = %i", scan_channel, n);
       if (n < 0){
         //Got a scan error, add a delay to allow other tasks on this core to run and to hopefully let WiFi issues settle down

--- a/B/B.ino
+++ b/B/B.ino
@@ -46,6 +46,7 @@ boolean ota_mode = false; //Set to true automatically when doing OTA update
 String ota_hash = ""; //SHA256 of the OTA update, set automatically.
 
 boolean using_bw16 = false; //Set when advanced config is sb_bw16=yes https://wardriver.uk/advanced_config
+boolean scan_passive = false; // WiFi scan in passive mode? - Default = FALSE (active scan) - does NOT apply to BW16
 
 // The WiFi channels to scan with the B-side ESP32
 // This is in prioritized order should we also be scanning Bluetooth, we will only scan the first 6 entries
@@ -203,6 +204,10 @@ void setup() {
     // BlueTooth scan preference
     if (buff.indexOf("scanble=no") > -1){
       scanBLE = false;
+    }
+    // WiFi scan mode preference - catch if passive mode is TRUE
+    if (buff.indexOf("scan_passive=yes") > -1){
+      scan_passive = true;
     }
   }
 
@@ -474,13 +479,15 @@ void loop() {
     channel_max = 14;  // if we aren't scanning Bluetooth, scan all 14
   }
 
+    ESP_LOGI(LOG_TAG_GENERIC, "Scanning in Passive mode: %s", scan_passive ? "true" : "false");
+
   // Get the channel to scan from the array
   for (int y = 0; y < channel_max; y++) {  // scan the channels from the array
     wifi_scan_channel = channel_list[y];
   
     ESP_LOGV(LOG_TAG_GENERIC, "Start Scan C%i", wifi_scan_channel);
     //scanNetworks(bool async, bool show_hidden, bool passive, uint32_t max_ms_per_chan, uint8_t channel)
-    int n = WiFi.scanNetworks(false,true,false,110,wifi_scan_channel);
+    int n = WiFi.scanNetworks(false,true,scan_passive,110,wifi_scan_channel);
     ESP_LOGV(LOG_TAG_GENERIC, "Finish Scan C%i = %i", wifi_scan_channel, n);
     if (n > 0){
       for (int i = 0; i < n; i++) {

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ To upload code to your ESP32 boards, please use the following configuration in t
 - PSRAM: `Disabled`
 - Arduino Runs On: `Core 1`
 - Events Run On: `Core 1`
+- Core Debug Level: `Debug` or `Verbose`
 
 If you have upload issues, try lowering the upload speed. Some users also report having to hold the "boot" button on the ESP32 board after connecting it to their PC before pressing the upload button in the Arduino IDE.
+
+Note on Logging: Effective in version 1.3 the 'Core Debug Level' setting in the Arduino IDE controls which logs will be sent to the Serial monitor. This is a compile time parameter, so if you change the level (for example from Debug to Verbose) you must reflash the ESP32 boards.
 
 ## Flashing (from binary) [BETA]
 


### PR DESCRIPTION
With new logging calls in v1.3, users flashing via the Arduino IDE must set the Core Debug Level to get any log output in the IDE Serial Monitor. 