### PR TITLE
Switch BLE scanning from Espressif stack to NimBLE.

### DIFF
--- a/B/B.ino
+++ b/B/B.ino
@@ -6,9 +6,7 @@
 //Serial2 = SIM800L module, 9600
 
 #include <WiFi.h>
-#include <BLEDevice.h>
-#include <BLEScan.h>
-#include <BLEAdvertisedDevice.h>
+#include <NimBLEDevice.h>
 #include <Update.h>
 #include "mbedtls/sha256.h"
 #include "mbedtls/md.h"
@@ -273,8 +271,8 @@ void setup() {
   // * BLUETOOTH setup if our PREFERENCE is ENABLED *
   if (scanBLE) {
     ESP_LOGD(LOG_TAG_GENERIC, "Setting up Bluetooth scanning");
-    BLEDevice::init("");
-    pBLEScan = BLEDevice::getScan(); //create new scan
+    NimBLEDevice::init("");
+    pBLEScan = NimBLEDevice::getScan(); //create new scan
     pBLEScan->setActiveScan(false); //active scan uses more power, but get results faster
     pBLEScan->setInterval(100);
     pBLEScan->setWindow(50);  // less or equal setInterval value
@@ -416,15 +414,21 @@ void loop() {
   // * Scanning BLUETOOTH only if preference is ENABLED *
   if (scanBLE) {
     ESP_LOGD(LOG_TAG_GENERIC, "Start BLE scan");
-    BLEScanResults* foundDevices = pBLEScan->start(1, false);
-    ble_found = foundDevices->getCount();
+    NimBLEScanResults foundDevices = pBLEScan->getResults(1000, false);
+    ble_found = foundDevices.getCount();
     
     for (int i = 0; i < ble_found; i++) {
       unsigned char mac_bytes[6];
       int values[6];
 
-      BLEAdvertisedDevice device = foundDevices->getDevice(i);
-      if (6 == sscanf(device.getAddress().toString().c_str(), "%x:%x:%x:%x:%x:%x%*c", &values[0], &values[1], &values[2], &values[3], &values[4], &values[5])){
+      const NimBLEAdvertisedDevice* device = foundDevices.getDevice(i);
+      if (!device) {
+        continue;
+      }
+
+      String addrStr = device->getAddress().toString().c_str();
+
+      if (6 == sscanf(addrStr.c_str(), "%x:%x:%x:%x:%x:%x%*c", &values[0], &values[1], &values[2], &values[3], &values[4], &values[5])){
         for(int i = 0; i < 6; ++i ){
             mac_bytes[i] = (unsigned char) values[i];
         }
@@ -432,15 +436,15 @@ void loop() {
         if (!seen_mac(mac_bytes)){
           save_mac(mac_bytes);
 
-          String ble_name = device.getName().c_str();
+          String ble_name = device->getName().c_str();
           ble_name.replace(",","_");
 
           await_serial();
           serial_lock = true;
           Serial1.print("BL,");
-          Serial1.print(device.getRSSI());
+          Serial1.print(device->getRSSI());
           Serial1.print(",");
-          Serial1.print(device.getAddress().toString().c_str());
+          Serial1.print(addrStr);
           Serial1.print(",");
           Serial1.println(ble_name);
           serial_lock = false;

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In order for the project to compile, you need to download the following librarie
 - [Adafruit SSD1306](https://github.com/adafruit/Adafruit_SSD1306) v2.5.x by Adafruit
 - [OneWire](https://www.pjrc.com/teensy/td_libs_OneWire.html) at least v2.3.7 by Paul Stoffregen
 - [GParser](https://github.com/GyverLibs/GParser) v1.4.x by AlexGyver
+- [NimBLE-Arduino](https://github.com/h2zero/NimBLE-Arduino) v2.3.9 by h2zero
 
 You can find the exact version number which should be installed in the file `libraries.txt`.
 

--- a/libraries.txt
+++ b/libraries.txt
@@ -3,3 +3,4 @@ Adafruit GFX Library@1.11.10
 Adafruit SSD1306@2.5.11
 OneWire@2.3.8
 GParser@1.5.2
+NimBLE-Arduino@2.3.9


### PR DESCRIPTION
Switching from the Espressif stack to NimBLE removes unneeded linked libraries and drastically reduces final binary size.